### PR TITLE
Add NYT logo and link back to main site

### DIFF
--- a/src/Components/Header/Header.css
+++ b/src/Components/Header/Header.css
@@ -1,0 +1,7 @@
+header {
+  margin: 1%;
+}
+
+.logo {
+  width: 2%;
+}

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -3,6 +3,7 @@ import './Header.css';
 const Header = () => {
   return (
     <header>
+      <a href="https://www.nytimes.com/" target="_blank"><img src="https://newcanaanlibrary.org/wp-content/uploads/2016/12/nyt-t-logo.png" alt="New York Times logo" className="logo" /></a>
       <h1>NYT Reader</h1>
       <h3>Top Articles From The New York Times</h3>
     </header>


### PR DESCRIPTION
Added NYT logo to header, made logo link back to main NYT site.